### PR TITLE
Use Picasso.get() instead of Picasso.with()

### DIFF
--- a/app/src/main/java/com/antonioleiva/weatherapp/ui/adapters/ForecastListAdapter.kt
+++ b/app/src/main/java/com/antonioleiva/weatherapp/ui/adapters/ForecastListAdapter.kt
@@ -41,7 +41,7 @@ class ForecastListAdapter(private val weekForecast: ForecastList,
 
         fun bindForecast(forecast: Forecast) {
             with(forecast) {
-                Picasso.with(itemView.ctx).load(iconUrl).into(iconView)
+                Picasso.get().load(iconUrl).into(iconView)
                 dateView.text = date
                 descriptionView.text = description
                 maxTemperatureView.text = "${high}º"


### PR DESCRIPTION
For newer Picasso versions(i.e 2.71828) use  `Picasso.get().load(iconUrl).into(iconView)` instead of `Picasso.with(itemView.ctx).load(iconUrl).into(iconView)`